### PR TITLE
Mobile nav refactor

### DIFF
--- a/src/js/back-to-top.js
+++ b/src/js/back-to-top.js
@@ -1,30 +1,32 @@
 module.exports = $(function(){
-  if ( $('#back-to-top').length ) {
-    var scrollTrigger = 100, // px
-      backToTop = function () {
-        var scrollTop = $(window).scrollTop();
-        if (scrollTop > scrollTrigger) {
-          $('#back-to-top').addClass('show');
-        } else {
+  if (Foundation.MediaQuery.atLeast('medium')) {
+    if ( $('#back-to-top').length ) {
+      var scrollTrigger = 100, // px
+        backToTop = function () {
+          var scrollTop = $(window).scrollTop();
+          if (scrollTop > scrollTrigger) {
+            $('#back-to-top').addClass('show');
+          } else {
+            $('#back-to-top').removeClass('show');
+          }
+        };
+
+      backToTop();
+
+      $(window).on('scroll', function () {
+        backToTop();
+        if ( $('#full-footer-start').offset().top < $(this).height() + $(this).scrollTop() ){
           $('#back-to-top').removeClass('show');
         }
-      };
 
-    backToTop();
+      });
 
-    $(window).on('scroll', function () {
-      backToTop();
-      if ( $('#full-footer-start').offset().top < $(this).height() + $(this).scrollTop() ){
-        $('#back-to-top').removeClass('show');
-      }
-
-    });
-
-    $('#back-to-top').on('click', function (e) {
-      e.preventDefault();
-      $('html,body').animate({
-        scrollTop: 0
-      }, 700);
-    });
+      $('#back-to-top').on('click', function (e) {
+        e.preventDefault();
+        $('html,body').animate({
+          scrollTop: 0
+        }, 700);
+      });
+    }
   }
 });

--- a/src/js/phila-gov.js
+++ b/src/js/phila-gov.js
@@ -103,12 +103,10 @@ module.exports = $(function(){
   $(document).on('hide.zf.dropdown', '[data-dropdown]', function() {
     $('body').removeClass('no-scroll');
     if ( !$('.is-drilldown').is(':visible') ){
-
       $('#page').removeClass('hide');
       $('footer').removeClass('hide');
+      Foundation.reInit('Equalizer');
     }
-    Foundation.reInit('Equalizer');
-
   });
 
 

--- a/src/js/phila-gov.js
+++ b/src/js/phila-gov.js
@@ -2,7 +2,6 @@ module.exports = $(function(){
 
   /*Globals */
   var navHeight = $('.global-nav').height();
-  var currentPath = window.location.pathname;
   var windowWidth = $(window).width();
 
   //Generic class for links that should prevent clickthrough
@@ -10,116 +9,30 @@ module.exports = $(function(){
     e.preventDefault();
   });
 
-  $('.top-bar').css( 'top', navHeight );
-
   var translate = setTimeout(function() { $('#google_translate_element a').prepend('<i class="fa fa-globe"></i>'); }, 1000);
 
-  /* Provide option for explict show/hide declarations, with jQuery fallbacks for older (ios) browsers */
-  function togglePageBody( show ){
-    if( show === true ){
-      $('#page').show();
-      $('#page').removeClass('hide');
-
-      $('footer').show();
-      $('footer').removeClass('hide');
-      return;
-    }
-
-    if( show === false ){
-
-      $('#page').hide();
-      $('#page').addClass('hide');
-
-      $('footer').hide();
-      $('footer').addClass('hide');
-      return;
-    }
-    $('#page').toggle();
-    $('#page').toggleClass('hide');
-
-    $('footer').toggle();
-    $('footer').toggleClass('hide');
-
-  }
+  var drilldownOptions = {
+    autoHeight: false,
+    scrollTop: true,
+    parentLink: true,
+    scrollTopElement: 'body'
+  };
+  var mobileMenu = new Foundation.Drilldown( $('#mobile-nav-drilldown'), drilldownOptions );
 
   /* Drilldown menu */
   $(document).on('toggled.zf.responsiveToggle', '[data-responsive-toggle]', function(){
-    var drilldownOptions = {dataAutoHeight: false, dataScrollTop: true};
-    var mobileMenu = new Foundation.Drilldown( $('.mobile-nav-drilldown'), drilldownOptions );
-
-    if ( $( '.js-current-section' ).length === 0 ) {
-      $('li.js-drilldown-back').after( '<li class="js-current-section" aria-hidden="false"></li>' );
-    }
-    $('li.js-drilldown-back').attr('tabindex', '1');
-
-    $('.mobile-nav-drilldown li').each( function() {
-        $(this).attr('tabindex', '0');
-    });
-
-    $('.menu-icon .title-bar-title').text( ( $('.menu-icon .title-bar-title' ).text() === 'Menu' ) ? 'Close' : 'Menu' );
-
-    $('.global-nav .menu-icon').toggleClass('active');
-
-    $('body').removeClass('no-scroll');
-
-    $('.menu-icon i').toggleClass('fa-bars').toggleClass('fa-close');
-
-    /* duplicate aria tags on drilldown parents, to allow full tap on item */
-    $('li.is-drilldown-submenu-parent').each(function() {
-      var aria = $(this).attr('aria-label');
-      $(this).children('a').first().attr('aria-label', aria);
-    });
-
-    if($('.mobile-nav-drilldown').is(':visible')){
-      togglePageBody(false);
-    }else{
-      togglePageBody(true);
-    }
+    extendMenuToggle();
   });
 
-  var parentLink = ['Main Menu'];
-
+  //opened submenu
   $(document).on('open.zf.drilldown', '[data-drilldown]', function(){
-
-    $('body').scrollTop('0');
-
-    parentLink.push( $(this).find('.is-active').last().prev().text() );
-
-    $(this).find('.is-active').last().addClass('current-parent');
-
-    $('.current-parent > li.js-drilldown-back a').text( 'Back to ' + parentLink.slice(-2)[0] );
-
-    $('.js-current-section').html( parentLink.slice(-1)[0] );
-
     /* Ensure no events get through on titles */
-    $('.js-current-section').each(function( ) {
+    $('.is-submenu-parent-item').each(function( ) {
       $(this).click(function(e) {
         return false;
       });
-
     });
-    //don't let events bubble up and cause issues on ul click
-    $( 'ul.is-active' ).click(function( e ) {
-      e.stopPropagation();
-    });
-
-    $(this).find('.is-active').attr('aria-hidden', 'false');
-
-    $(this).find('.is-drilldown-submenu').not('.is-active').attr('aria-hidden', 'true');
-
-
   });
-
-
-  $(document).on('hide.zf.drilldown', '[data-drilldown]', function(){
-    parentLink.pop();
-
-    $('.current-parent > li.js-drilldown-back a').text( 'Back to ' + parentLink.slice(-2)[0] );
-
-    $('.js-current-section').html( parentLink.slice(-1)[0] );
-
-  });
-
 
   $('#services-mega-menu').hover( function(){
     $( '.site-search i' ).addClass('fa-search').removeClass('fa-close');
@@ -130,30 +43,17 @@ module.exports = $(function(){
 
   });
 
+  function extendMenuToggle(){
+    $('.menu-icon i').toggleClass('fa-bars').toggleClass('fa-close');
+    $('.menu-icon .title-bar-title').text( ( $('.menu-icon .title-bar-title' ).text() === 'Menu' ) ? 'Close' : 'Menu' );
+    $('.global-nav .menu-icon').toggleClass('active');
+    $('#page').toggleClass('hide');
+    $('footer').toggleClass('hide');
 
-  function resetLayout(){
-    $('.menu-icon .title-bar-title').text('Menu');
-    $('.menu-icon').removeClass('active');
-
-    $('#services-mega-menu').foundation('close');
-
-    resetTopBar();
+    Foundation.reInit('Equalizer');
   }
 
-  function resetTopBar(){
-    $('body').removeClass('no-scroll');
-    $( '.site-search i' ).addClass('fa-search').removeClass('fa-close');
-    $('.menu-icon i').addClass('fa-bars').removeClass('fa-close');
-  }
-
-  function menuToggle(){
-    if ( $('.is-drilldown').is(':visible') ) {
-      $('.title-bar').foundation('toggleMenu');
-      togglePageBody(true);
-    }
-  }
-
-  function checkBrowserHeight( navHeight ){
+  function checkBrowserHeight( ){
     if ( $('body').hasClass('logged-in') ) {
       return;
     }
@@ -169,30 +69,29 @@ module.exports = $(function(){
     }
 
     if ( wh <= sh ) {
-      $('#services-mega-menu').css({
+      $('.mega-menu-dropdown').css({
         'position': 'absolute',
-        'top': 0
+        'top': '0'
       });
 
-      togglePageBody( false );
       $('body').removeClass('no-scroll');
+      $('#page').addClass('hide');
+      $('footer').addClass('hide');
 
     }else{
 
-      togglePageBody( true );
       $('body').addClass('no-scroll');
+      $('#page').removeClass('hide');
+      $('footer').removeClass('hide');
 
     }
 
   }
 
   /* Mega menu Dropdown */
-
   $('#services-mega-menu').on('show.zf.dropdown', function() {
-
     $('#back-to-top').css('display', 'none');
-
-    checkBrowserHeight( navHeight );
+    checkBrowserHeight();
   });
 
 
@@ -204,14 +103,23 @@ module.exports = $(function(){
 
   /* All dropdowns */
   $(document).on('hide.zf.dropdown', '[data-dropdown]', function() {
-    togglePageBody( true );
     $('body').removeClass('no-scroll');
+    if ( !$('.is-drilldown').is(':visible') ){
+
+      $('#page').removeClass('hide');
+      $('footer').removeClass('hide');
+    }
+    Foundation.reInit('Equalizer');
+
   });
 
 
   /* Site search dropdown */
   $('.site-search-dropdown').on('show.zf.dropdown', function(){
-    menuToggle();
+    //menu toggle close when menu is already open
+    if ( $('.is-drilldown').is(':visible') ){
+      $('.title-bar').foundation('toggleMenu');
+    }
     $( '.site-search i' ).addClass('fa-close').removeClass('fa-search');
 
     $('.site-search span').text( ( $('.site-search span' ).text() === 'Search' ) ? 'Close' : 'Search' );
@@ -223,7 +131,6 @@ module.exports = $(function(){
     }
 
     $(this).css('top', navHeight);
-
   });
 
   $('.site-search-dropdown').on('hide.zf.dropdown', function() {
@@ -232,41 +139,24 @@ module.exports = $(function(){
   });
 
 
-  function drilldownMenuHeight(){
-    if (Foundation.MediaQuery.current === 'small') {
-      var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
-
-      var drilldownHeight = $('.global-nav .is-drilldown').outerHeight();
-      var singleHeight = $('.global-nav .is-drilldown li').outerHeight() + 10;
-      $('.global-nav .is-drilldown ul').css({
-        'height': drilldownHeight +  singleHeight + 'px'
-      });
-    }
-  }
-
   $( window ).resize(function() {
-
     //check window width for mobile devices to prevent window resize on scroll.
     if ($(window).width() !== windowWidth) {
       windowWidth = $(window).width();
 
-      checkBrowserHeight( navHeight ) ;
+      //checkBrowserHeight( navHeight ) ;
 
       if (Foundation.MediaQuery.atLeast('medium')) {
-        resetLayout();
+        $('#page').removeClass('hide');
+        $('footer').removeClass('hide');
       }
     }
-    $(window).bind('orientationchange', function(e){
-      resetLayout();
-    });
-
     //orientation doesn't matter, always remove the no-scroll class
     $('body').removeClass('no-scroll');
   });
 
 
   /* prevent search dropdown from becoming dissconnected from header when keyboard is closed on iOS devices */
-
   $('.search-field').focusout(function() {
     if ( Foundation.MediaQuery.current === 'small' ) {
       window.scrollTo(0, 0);

--- a/src/js/phila-gov.js
+++ b/src/js/phila-gov.js
@@ -81,9 +81,7 @@ module.exports = $(function(){
     }else{
 
       $('body').addClass('no-scroll');
-      $('#page').removeClass('hide');
-      $('footer').removeClass('hide');
-
+      showBodyContent();
     }
 
   }
@@ -138,6 +136,10 @@ module.exports = $(function(){
     $('.site-search span').text('Search');
   });
 
+  function showBodyContent(){
+    $('#page').removeClass('hide');
+    $('footer').removeClass('hide');
+  }
 
   $( window ).resize(function() {
     //check window width for mobile devices to prevent window resize on scroll.
@@ -147,8 +149,7 @@ module.exports = $(function(){
       //checkBrowserHeight( navHeight ) ;
 
       if (Foundation.MediaQuery.atLeast('medium')) {
-        $('#page').removeClass('hide');
-        $('footer').removeClass('hide');
+        showBodyContent();
       }
     }
     //orientation doesn't matter, always remove the no-scroll class

--- a/src/js/phila-gov.js
+++ b/src/js/phila-gov.js
@@ -105,7 +105,6 @@ module.exports = $(function(){
     if ( !$('.is-drilldown').is(':visible') ){
       $('#page').removeClass('hide');
       $('footer').removeClass('hide');
-      Foundation.reInit('Equalizer');
     }
   });
 

--- a/src/sass/_settings.scss
+++ b/src/sass/_settings.scss
@@ -140,7 +140,7 @@ $code-font-weight: $global-weight-normal;
 $code-background: color(ghost-gray);
 $code-border: none;
 $code-padding: rem-calc(2 5 1);
-$anchor-color: color(ben-franklin-blue);
+$anchor-color: color(dark-ben-franklin);
 $anchor-color-hover: color(dark-gray);
 $anchor-text-decoration: none;
 $anchor-text-decoration-hover: none;
@@ -322,9 +322,9 @@ $closebutton-color-hover: color(black);
 
 $drilldown-transition: transform 0.15s linear;
 $drilldown-arrows: true;
-$drilldown-arrow-color: $primary-color;
+$drilldown-arrow-color: color(dark-ben-franklin);
 $drilldown-arrow-size: 6px;
-$drilldown-background: color(white);
+$drilldown-background: color(ghost-gray);
 
 // 17. Dropdown
 // ------------
@@ -627,8 +627,8 @@ $tooltip-radius: $global-radius;
 // -----------
 
 $topbar-padding: 0;
-$topbar-background: transparent;
-$topbar-submenu-background: $topbar-background;
+$topbar-background: color(ghost-gray);
+$topbar-submenu-background: color(ghost-gray);
 $topbar-title-spacing: 0.5rem 1rem 0.5rem 0;
 $topbar-input-width: auto;
 $topbar-unstack-breakpoint: medium;

--- a/src/sass/layout/_global-nav.scss
+++ b/src/sass/layout/_global-nav.scss
@@ -84,6 +84,10 @@
     max-width: 100% !important;
     left:0 !important;
 
+    @include breakpoint(small only) {
+      top: 0 !important;
+    }
+
     &.is-stuck{
       box-shadow: 0 3px 10px rgba(color(medium-gray), .5);
     }

--- a/src/sass/layout/_global-nav.scss
+++ b/src/sass/layout/_global-nav.scss
@@ -1,4 +1,8 @@
-//TODO: refacor this file
+#mobile-nav{
+  padding-right:0;
+  padding-left:0;
+}
+
 .global-nav {
   @include secondary-font(400);
   position: relative;
@@ -11,10 +15,10 @@
 
   .js-is-current {
     color:color(white);
-    background: color(ben-franklin-blue);
+    background: color(dark-ben-franklin);
     &:hover,
     &:active{
-      color:color(ben-franklin-blue);
+      color:color(dark-ben-franklin);
       background: color(light-blue);
     }
   }
@@ -29,8 +33,6 @@
     }
   }
   //utility nav
-  //TODO: deprecate .secondary-nav in this location.
-  .secondary-nav,
   .utility-nav {
     font-size: .85rem;
 
@@ -86,9 +88,10 @@
       box-shadow: 0 3px 10px rgba(color(medium-gray), .5);
     }
 
-    @include breakpoint(small only) {
-      position: relative;
-      z-index: auto;
+    .sticky-header-width{
+      max-width: 75rem;
+      margin-left: auto;
+      margin-right: auto;
     }
 
   }
@@ -96,7 +99,6 @@
   .title-bar {
     color:color(dark-ben-franklin);
     position: absolute;
-    z-index: 10;
 
     .menu-icon {
       position: relative;
@@ -114,7 +116,7 @@
       }
 
       &:after, &:before {
-        background: color(ben-franklin-blue);
+        background: color(dark-ben-franklin);
         box-shadow: none;
         height: 0;
       }
@@ -130,21 +132,10 @@
     }
   }
 
-  .is-drilldown-submenu-parent a::after {
-    margin-top:-6px;
-  }
-
   .is-drilldown {
-    overflow: visible;
     max-width: 100% !important;
 
     ul {
-      background: color(ghost-gray);
-      width: 100%;
-      height: inherit;
-      margin: 0;
-      padding:0;
-      bottom:0;
 
       li {
         background: color(ghost-gray);
@@ -160,14 +151,23 @@
         a{
           padding:1rem;
           display: block;
-
+          line-height: 1;
 
           &:hover,
           &:active {
-            background: color(ben-franklin-blue);
+            background: color(dark-ben-franklin);
             color:color(white);
           }
         }
+      }
+    }
+    .is-submenu-parent-item{
+      font-size: 1.3rem;
+      a:link, a:hover, a:active{
+        background:color(ghost-gray);
+        cursor: default;
+        color: color(black);
+
       }
     }
     .is-drilldown-submenu-parent > a {
@@ -183,6 +183,7 @@
       }
     }
 
+
     .js-drilldown-back{
       >a:hover::before,
       >a:active::before{
@@ -196,20 +197,13 @@
     }
 
     .top-bar{
-      background-color: color(ghost-gray);
-      position: absolute;
-      z-index:11;
-      //overflow: scroll;
-      //height:200px;
-      //TODO: calcuate this w/ js
-      //top:83px;
+      background-color: color(white);
       &.no-js{
         display:none;
       }
     }
 
   }
-
 
   @include breakpoint( medium ) {
     .services-menu-link {
@@ -266,7 +260,7 @@
       }
        //this is to account for when the dropdown panel is visible AND when the normal :hover state is active
       &.hover {
-        background: color(ben-franklin-blue);
+        background: color(dark-ben-franklin);
 
         //panel is open
         a{
@@ -317,7 +311,7 @@
 
        &:hover::after,
        &:active::after{
-        border-color: color(ben-franklin-blue) transparent transparent transparent;
+        border-color: color(dark-ben-franklin) transparent transparent transparent;
 
        }
        &::after {
@@ -340,7 +334,7 @@
        }
         &.js-is-current {
           color:color(white);
-          background: color(ben-franklin-blue);
+          background: color(dark-ben-franklin);
 
           &::after{
             border-color: color(white) transparent transparent transparent;
@@ -386,7 +380,7 @@
 
         &:hover {
           color:color(white);
-          background: color(ben-franklin-blue);
+          background: color(dark-ben-franklin);
         }
         span{
           display:block;
@@ -400,7 +394,7 @@
         color: color(white);
         &:hover {
           background:color(white);
-          color:color(ben-franklin-blue);
+          color:color(dark-ben-franklin);
         }
       }
       .left-arrow-indent{
@@ -505,6 +499,19 @@ header {
       @include breakpoint(medium) {
         right: 1rem;
       }
+    }
+  }
+}
+.no-js {
+  @include breakpoint(small only) {
+    .top-bar {
+      display: none;
+    }
+  }
+
+  @include breakpoint(medium) {
+    .title-bar {
+      display: none;
     }
   }
 }

--- a/src/sass/layout/_hero-header.scss
+++ b/src/sass/layout/_hero-header.scss
@@ -34,8 +34,6 @@
     @include breakpoint(medium up) {
       margin-bottom:0;
       text-align: center;
-      //TODO: replace "department-menu" with more semantic "secondary-menu"
-      .department-menu,
       .secondary-menu {
         background: none;
         .dropdown li{
@@ -52,12 +50,7 @@
               padding: $spacing-small $spacing-large;
             }
             > a::after{
-              content: '';
               display: inline;
-              border-left: 5px solid transparent;
-              border-right: 5px solid transparent;
-              border-top: 5px solid color(white);
-              border-bottom: none;
               left: 5px;
               position: relative;
               margin: auto 0;


### PR DESCRIPTION
This cleans up a good amount of pre-foundation 6.3.1 menu hacks.
* Remove redundant mobile nav code
* Use foundation built-in methods to pass options to mobile drilldown
* Correct menu colors especially drilldown menu
* Allows site menus in mobile view to use accordion menu